### PR TITLE
Updated 1.2.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<37]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,20 +6,21 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/openapi-schema-pydantic-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/o/openapi-schema-pydantic/openapi-schema-pydantic-{{ version }}.tar.gz
   sha256: 3e22cf58b74a69f752cc7e5f1537f6e44164282db2700cbbcd3bb99ddd065196
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - pydantic >=1.8.2
 
 test:
@@ -32,12 +33,14 @@ test:
 
 about:
   home: https://github.com/kuimono/openapi-schema-pydantic
+  doc_url: https://github.com/kuimono/openapi-schema-pydantic
+  dev_url: https://github.com/kuimono/openapi-schema-pydantic
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
   summary: OpenAPI (v3) specification schema as pydantic class
-  license: Apache-2.0 AND MIT
-  license_file:
-    - LICENSE
-    - openapi_schema_pydantic/v3/v3_0_3/license.py
-    - openapi_schema_pydantic/v3/v3_1_0/license.py
+  description: |
+    OpenAPI (v3) specification schema as Pydantic classes. The naming of the classes follows the schema in OpenAPI specification.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
### **Overview**

Jira: https://anaconda.atlassian.net/browse/PKG-1765

1. Added forked submodule
2. Updated 1.2.4 to align with recipe standards:
- removed `noarch: python`
- added `--no-deps` and `--no-build-isolation`
- removed python pinnings
- added `setuptools` and `wheel`
- added `doc_url`, `dev_url`, `license_family`, and `description`